### PR TITLE
Fix the order for filtering projects

### DIFF
--- a/src/hub-for-good-list/templates/app.vue
+++ b/src/hub-for-good-list/templates/app.vue
@@ -101,14 +101,17 @@ limitations under the License.
 
     // Parse links in project & standardise purposes
     const projectData = data.map(project => {
+        const link = Linkify.match(project.link);
+        if (link === null) return null;
+
         const purpose = validPurposes.includes(project.purpose) ? project.purpose : 'other';
         purposeMap[purpose][1]++;
         return {
             ...project,
-            link: Linkify.match(project.link),
+            link,
             purpose,
         };
-    }).filter(project => project.link !== null);
+    }).filter(project => project !== null);
 
     // Create the data for the purposes filter
     const getFilterPurposes = () => {


### PR DESCRIPTION
## Type of Change

- **Tool Source:** App project filtering

## What issue does this relate to?

N/A

### What should this PR do?

Count did not match length due to filtering after tracking count. This filters before counting.

### What are the acceptance criteria?

Counts in dropdown match rendered table items count.