### PR TITLE
Fix continual pushes for GH Pages, remove report

### DIFF
--- a/.github/workflows/gh-pages-workflow.yml
+++ b/.github/workflows/gh-pages-workflow.yml
@@ -6,6 +6,7 @@ on:
       - master
   schedule:
     - cron: '0 12,15,18,21 * * *'
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -37,6 +38,9 @@ jobs:
         GOOGLE_CLIENT_EMAIL: ${{ secrets.GOOGLE_CLIENT_EMAIL }}
         GOOGLE_PRIVATE_KEY: ${{ secrets.GOOGLE_PRIVATE_KEY }}v
         GOOGLE_SHEET_ID: ${{ secrets.GOOGLE_SHEET_ID }}
+
+    - name: Clean build output
+      run: rm dist/report.html
 
     - name: Deploy master to GitHub Pages
       uses: JamesIves/github-pages-deploy-action@v4


### PR DESCRIPTION
## Type of Change

- **Build Scripts:** GitHub Pages workflow

## What issue does this relate to?

cc https://github.com/do-community/available-images/pull/37

### What should this PR do?

Comparing the last two hashes pushed to GitHub Pages, the only difference was the report:

```
git --no-pager diff --no-index --unified=0 ~/Downloads/hub-for-good-list-8a01f1eab1d75eb2ae80b13b87bedfdc1cf8891e ~/Downloads/hub-for-good-list-cfe0bc9e6fc238f7d1ca3ebe17e726bb4236bbd0 
diff --git a/Users/mattcowley/Downloads/hub-for-good-list-8a01f1eab1d75eb2ae80b13b87bedfdc1cf8891e/report.html b/Users/mattcowley/Downloads/hub-for-good-list-cfe0bc9e6fc238f7d1ca3ebe17e726bb4236bbd0/report.html
index db7e379..2df78e2 100644
--- a/Users/mattcowley/Downloads/hub-for-good-list-8a01f1eab1d75eb2ae80b13b87bedfdc1cf8891e/report.html
+++ b/Users/mattcowley/Downloads/hub-for-good-list-cfe0bc9e6fc238f7d1ca3ebe17e726bb4236bbd0/report.html
@@ -6 +6 @@
-    <title>hub-for-good-list [14 May 2023 at 21:01]</title>
+    <title>hub-for-good-list [15 May 2023 at 12:08]</title>
```

We don't actually need that report in the GitHub Pages output at all, and it is causing us to push every single run, rather than only when the output actually changes. This PR removes the report from the output so that we don't continually push to pages.

### What are the acceptance criteria?

Report removed from GitHub Pages output.
